### PR TITLE
Add workflow component and support for lazy-starting the workflow engine

### DIFF
--- a/pkg/actors/actors_mock.go
+++ b/pkg/actors/actors_mock.go
@@ -33,6 +33,10 @@ type MockActors struct {
 	mock.Mock
 }
 
+func (_m *MockActors) RegisterInternalActor(ctx context.Context, actorType string, actor InternalActor) error {
+	return nil
+}
+
 // Call provides a mock function with given fields: req
 func (_m *MockActors) Call(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
 	ret := _m.Called(req)
@@ -236,6 +240,10 @@ func (_m *MockActors) GetActiveActorsCount(ctx context.Context) []ActiveActorsCo
 
 type FailingActors struct {
 	Failure daprt.Failure
+}
+
+func (f *FailingActors) RegisterInternalActor(ctx context.Context, actorType string, actor InternalActor) error {
+	return nil
 }
 
 func (f *FailingActors) Call(ctx context.Context, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {

--- a/pkg/actors/internal/placement.go
+++ b/pkg/actors/internal/placement.go
@@ -15,6 +15,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -111,6 +112,19 @@ func NewActorPlacement(
 		appHealthFn:         appHealthFn,
 		afterTableUpdateFn:  afterTableUpdateFn,
 	}
+}
+
+// Register an actor type by adding it to the list of known actor types (if it's not already registered)
+// The placement tables will get updated when the next heartbeat fires
+func (p *ActorPlacement) AddHostedActorType(actorType string) error {
+	for _, t := range p.actorTypes {
+		if t == actorType {
+			return fmt.Errorf("actor type %s already registered", actorType)
+		}
+	}
+
+	p.actorTypes = append(p.actorTypes, actorType)
+	return nil
 }
 
 // Start connects placement service to register to membership and send heartbeat

--- a/pkg/actors/internal_actor_test.go
+++ b/pkg/actors/internal_actor_test.go
@@ -108,8 +108,14 @@ func newTestActorsRuntimeWithInternalActors(internalActors map[string]InternalAc
 		TracingSpec:    spec,
 		Resiliency:     resiliency.New(log),
 		StateStoreName: "actorStore",
-		InternalActors: internalActors,
 	})
+
+	for actorType, actor := range internalActors {
+		if err := a.RegisterInternalActor(context.TODO(), actorType, actor); err != nil {
+			return nil, err
+		}
+	}
+
 	if err := a.Init(); err != nil {
 		return nil, err
 	}

--- a/pkg/runtime/wfengine/component.go
+++ b/pkg/runtime/wfengine/component.go
@@ -1,0 +1,101 @@
+package wfengine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/dapr/components-contrib/workflows"
+	componentsV1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/kit/logger"
+	"github.com/microsoft/durabletask-go/api"
+	"github.com/microsoft/durabletask-go/backend"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var ComponentDefinition = componentsV1alpha1.Component{
+	TypeMeta: metav1.TypeMeta{
+		Kind: "Component",
+	},
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "dapr",
+	},
+	Spec: componentsV1alpha1.ComponentSpec{
+		Type:     "workflow.dapr",
+		Version:  "v1",
+		Metadata: []componentsV1alpha1.MetadataItem{},
+	},
+}
+
+func BuiltinWorkflowFactory(engine *WorkflowEngine) func(logger.Logger) workflows.Workflow {
+	return func(logger logger.Logger) workflows.Workflow {
+		return &WorkflowEngineComponent{
+			logger: logger,
+			engine: engine,
+		}
+	}
+}
+
+type WorkflowEngineComponent struct {
+	workflows.Workflow
+	logger logger.Logger
+	engine *WorkflowEngine
+}
+
+func (c *WorkflowEngineComponent) Init(metadata workflows.Metadata) error {
+	c.logger.Infof("Initializing Dapr workflow engine")
+	return nil
+}
+
+func (c *WorkflowEngineComponent) Start(ctx context.Context, req *workflows.StartRequest) (*workflows.WorkflowReference, error) {
+	if req.WorkflowReference.InstanceID == "" {
+		return nil, fmt.Errorf("no workflow instance ID supplied")
+	}
+
+	wi := &backend.OrchestrationWorkItem{
+		InstanceID: api.InstanceID(req.WorkflowReference.InstanceID),
+	}
+
+	if err := c.engine.backend.ScheduleWorkflow(ctx, wi); err != nil {
+		c.logger.Warnf("Unable to schedule workflow: %v", err)
+		return nil, fmt.Errorf("unable to start workflow: %v", err)
+	}
+
+	return &workflows.WorkflowReference{
+		InstanceID: req.WorkflowReference.InstanceID,
+	}, nil
+}
+
+func (c *WorkflowEngineComponent) Terminate(ctx context.Context, req *workflows.WorkflowReference) error {
+	if req.InstanceID == "" {
+		return fmt.Errorf("no workflow instance ID supplied")
+	}
+
+	wi := &backend.OrchestrationWorkItem{
+		InstanceID: api.InstanceID(req.InstanceID),
+	}
+
+	if err := c.engine.backend.AbandonOrchestrationWorkItem(ctx, wi); err != nil {
+		return fmt.Errorf("failed to terminate workflow %s: %v", req.InstanceID, err)
+	}
+
+	return nil
+}
+
+func (c *WorkflowEngineComponent) Get(ctx context.Context, req *workflows.WorkflowReference) (*workflows.StateResponse, error) {
+	if req.InstanceID == "" {
+		return nil, fmt.Errorf("no workflow instance ID supplied")
+	}
+
+	workId := api.InstanceID(req.InstanceID)
+
+	if metadata, err := c.engine.backend.GetOrchestrationMetadata(ctx, workId); err != nil {
+		return nil, fmt.Errorf("failed to get workflow metadata for %s: %v", req.InstanceID, err)
+	} else {
+		return &workflows.StateResponse{
+			WFInfo: workflows.WorkflowReference{
+				InstanceID: req.InstanceID,
+			},
+			StartTime: metadata.CreatedAt.Local().String(),
+		}, nil
+	}
+}

--- a/pkg/runtime/wfengine/wfengine_test.go
+++ b/pkg/runtime/wfengine/wfengine_test.go
@@ -200,6 +200,10 @@ func marshal(val interface{}, marshaler func(interface{}) ([]byte, error)) ([]by
 
 type mockPlacement struct{}
 
+func (p *mockPlacement) AddHostedActorType(actorType string) error {
+	return nil
+}
+
 func NewMockPlacement() actors.PlacementService {
 	return &mockPlacement{}
 }
@@ -655,7 +659,6 @@ func getEngine() *wfengine.WorkflowEngine {
 		StateStore:     store,
 		Config:         cfg,
 		StateStoreName: "workflowStore",
-		InternalActors: engine.InternalActors(),
 		MockPlacement:  NewMockPlacement(),
 		Resiliency:     resiliency.New(logger.NewLogger("test")),
 	})


### PR DESCRIPTION
Adds the ability to late-register actors, rather than needing to provide them up-front, which also allows us to start the workflow engine after initialization. The intention is that the workflow engine itself will only start if an application registers workflows and activities so that it only runs if a user is using Dapr workflows.

Also adds a built-in auto-registered component for the Dapr workflow engine in order to use the management API to interact with it.

Signed-off-by: John Ewart <john@johnewart.net>